### PR TITLE
This commit would fix issue #1.  A mutex might be a cleaner solution, but this seemed the easiest way to handle it

### DIFF
--- a/meta_ssh/lib/rex/post/meta_ssh/channel.rb
+++ b/meta_ssh/lib/rex/post/meta_ssh/channel.rb
@@ -132,10 +132,17 @@ class Channel
       self.client.remove_channel(self)
       self.monitor.kill if self.monitor
       self.thread.kill if self.thread
-      self.channel.close
-      self.lsock.close
-    rescue Exception => e
-      puts e
+      self.channel.close if self.channel
+      self.lsock.close if self.lsock
+      monitor = thread = channel = lsock = nil
+    rescue ::IOError
+      # This happens if we get called in another thread before the lsock gets
+      # set to nil. Doesn't cause any trouble since the channel is closing
+      # anyway, so just ignore.
+    rescue ::Exception => e
+      # Something went wrong but the channel is dead anyway, so just log it and
+      # ignore.
+      elog "Exception while cleaning up channel: #{e.class}: #{e}"
     end
   end
 

--- a/meta_ssh/modules/exploits/multi/ssh/login_pubkey.rb
+++ b/meta_ssh/modules/exploits/multi/ssh/login_pubkey.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			[
 				Opt::RPORT(22),
         Opt::RHOST,
-        OptString.new('KEY_FILE', [ true, "The cleartext *private* key file to use" ]),
+        OptPath.new('KEY_FILE', [ true, "The cleartext *private* key file to use" ]),
         OptString.new('USER', [ true, "The username to use"]),
 			], self.class)
 	end


### PR DESCRIPTION
Channel#close gets called lots of times, so make sure that closing the
lsock doesn't break things by rescuing IOError.
